### PR TITLE
correct offset when scrollController with initialScrollOffset

### DIFF
--- a/lib/draggable_scrollbar.dart
+++ b/lib/draggable_scrollbar.dart
@@ -346,6 +346,16 @@ class _DraggableScrollbarState extends State<DraggableScrollbar>
       parent: _labelAnimationController,
       curve: Curves.fastOutSlowIn,
     );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) =>
+        _initOffsetForScrollInitialOffset());
+  }
+
+  /// init offset when widgets finish loading
+  void _initOffsetForScrollInitialOffset() {
+    _viewOffset = widget.controller.initialScrollOffset;
+    _barOffset = _viewOffset / viewMaxScrollExtent * barMaxScrollExtent;
+    setState(() {});
   }
 
   @override


### PR DESCRIPTION
## Current issue
When scrollController inits with initialScrollOffset, the scroll bar will always be with offset 0, and could not scroll it up vertically.

## Solution
Recalculate the offset when the widgets finish loading. Set the offset by initialScrollOffset.