### PR TITLE
fix #6 - Exceptions on animation controllers due to not dispose() on all

### DIFF
--- a/lib/draggable_scrollbar.dart
+++ b/lib/draggable_scrollbar.dart
@@ -350,6 +350,7 @@ class _DraggableScrollbarState extends State<DraggableScrollbar>
 
   @override
   void dispose() {
+    _labelAnimationController.dispose();
     _thumbAnimationController.dispose();
     _fadeoutTimer?.cancel();
     super.dispose();

--- a/lib/draggable_scrollbar.dart
+++ b/lib/draggable_scrollbar.dart
@@ -350,9 +350,9 @@ class _DraggableScrollbarState extends State<DraggableScrollbar>
 
   @override
   void dispose() {
+    _fadeoutTimer?.cancel();
     _labelAnimationController.dispose();
     _thumbAnimationController.dispose();
-    _fadeoutTimer?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
fix #6

* needed to dispose of both animation controllers
* need to cancel the timer before disposing of those two controllers