### PR TITLE
Fix scrollthumb shrinking when vertical padding provided

### DIFF
--- a/lib/draggable_scrollbar.dart
+++ b/lib/draggable_scrollbar.dart
@@ -357,7 +357,7 @@ class _DraggableScrollbarState extends State<DraggableScrollbar>
   }
 
   double get barMaxScrollExtent =>
-      context.size!.height - widget.heightScrollThumb;
+      context.size!.height - widget.heightScrollThumb - (widget.padding == null ? 0.0 : widget.padding!.vertical);
 
   double get barMinScrollExtent => 0.0;
 


### PR DESCRIPTION
When vertical padding is provided to the scrollbar, scroll thumb shrinks on reaching the end of scroll. This happens because `barMaxScrollExtent` doesn't count vertical padding provided to the widget.

My fix changes this behavior by subtracting `widget.padding?.vertical` in `barMaxScrollExtent`.